### PR TITLE
Added remaining endpoints for user configuration

### DIFF
--- a/app/routes/auth_route.py
+++ b/app/routes/auth_route.py
@@ -27,7 +27,7 @@ async def user_authenticate(user: User, response: Response):
             user_db["username"],
             user_db["picture"],
             user_db["role"],
-            str(user_db["_id"])
+            str(user_db["_id"]),
         ]
         return user_data
     else:
@@ -59,9 +59,9 @@ async def user_signup(user: User, response: Response):
     user_collection.insert_one(dict(user))
     return user_collection.find_one({"email": user.email})["email"]
 
-@auth_api_router.put("/{id}")
-async def user_update(id: str, user: User, response: Response):
-    # Check if a user with the same username already exists
+
+@auth_api_router.put("/{id}/username")
+async def username_update(id: str, user: User, response: Response):
     user_in_db = user_collection.find_one({"username": user.username})
     if user_in_db is not None:
         response.status_code = status.HTTP_409_CONFLICT
@@ -71,3 +71,51 @@ async def user_update(id: str, user: User, response: Response):
     "$set": {"username": user.username}
     })
     return "Username updated"
+
+
+@auth_api_router.put("/{id}/email")
+async def email_update(id: str, user: User, response: Response):
+    email_in_db = user_collection.find_one({"email": user.email})
+    if email_in_db is not None:
+        response.status_code = status.HTTP_409_CONFLICT
+        return "Email already exists"
+
+    user_db = user_collection.find_one({"_id": ObjectId(id)})
+    if check_password(user.password, user_db["password"], user_db["salt"]):
+        user_collection.find_one_and_update({"_id": ObjectId(id)}, {
+        "$set": {"email": user.email}
+        })
+        return "Email updated"
+    else:
+        response.status_code = status.HTTP_401_UNAUTHORIZED
+        return "User not authenticated"
+    
+
+@auth_api_router.put("/{id}/password")
+async def password_update(id: str, user: User, response: Response):
+    current_password = user.password.split(" ")[0]
+    new_password = user.password.split(" ")[1]
+    
+    user_db = user_collection.find_one({"_id": ObjectId(id)})
+    if check_password(current_password, user_db["password"], user_db["salt"]):
+        salt = generate_salt()
+        hashed_password = encrypt_password(new_password, salt)
+
+        user_collection.find_one_and_update({"_id": ObjectId(id)}, {
+        "$set": {"password": hashed_password, "salt": salt}
+        })
+        return "Password updated"
+    else:
+        response.status_code = status.HTTP_401_UNAUTHORIZED
+        return "User not authenticated"
+    
+
+@auth_api_router.delete("/{id}")
+async def user_delete(id: str, user: User, response: Response):
+    user_db = user_collection.find_one({"_id": ObjectId(id)})
+    if check_password(user.password, user_db["password"], user_db["salt"]) and user_db["email"] == user.email:
+        user_collection.find_one_and_delete({"_id": ObjectId(id)})
+        return "User deleted"
+    else:
+        response.status_code = status.HTTP_401_UNAUTHORIZED
+        return "User not authenticated"


### PR DESCRIPTION
Currently running the backend with Docker doesn't work for the new endpoints, due to the port being used. Instead, for now at least, use `uvicorn app.main:app` instead, as this runs the api on localhost:8000 which matches the development environment for the frontend. 